### PR TITLE
Avoid importing headers

### DIFF
--- a/dataLoader.sh
+++ b/dataLoader.sh
@@ -10,7 +10,7 @@ find "$DOWNLOAD_DIRECTORY/Authority Code" -name "*.psv" -print0 |
 while IFS= read -r -d '' line; do
   fileName="$(basename -- "$line")"
   tableName="$(echo $fileName | sed -rn 's/Authority_Code_(.*)_psv.psv/\1/p')"
-  (echo .mode csv; echo .separator "|"; echo .import \"${line}\" ${tableName}) | sqlite3 ${DATABASE_FILE}
+  (echo .mode csv; echo .separator "|"; echo .import --skip 1 \"${line}\" ${tableName}) | sqlite3 ${DATABASE_FILE}
 done
 
 echo "### Loading Standard Data"
@@ -18,7 +18,7 @@ find "$DOWNLOAD_DIRECTORY/Standard" -name "*.psv" -print0 |
 while IFS= read -r -d '' line; do
   fileName="$(basename -- "$line")"
   tableName="$(echo $fileName | sed -rn 's/(WA|NT|VIC|NSW|SA|TAS|OT|ACT|QLD)_(.*)_psv.psv/\2/p')"
-  (echo .mode csv; echo .separator "|"; echo .import \"${line}\" ${tableName}) | sqlite3 ${DATABASE_FILE}
+  (echo .mode csv; echo .separator "|"; echo .import --skip 1 \"${line}\" ${tableName}) | sqlite3 ${DATABASE_FILE}
 done
 
 # This is to cleanup the empty values in the import to NULL. Makes life easier later.


### PR DESCRIPTION
@ggotti all headers were imported into the tables. We can fix that by using the `--skip` switch.

![image](https://user-images.githubusercontent.com/4897141/126061713-0378a045-f853-4657-bc84-d36ec80c42eb.png)
